### PR TITLE
Added the ability to configure mongo hostname/port.

### DIFF
--- a/back-end/config/mongo.js
+++ b/back-end/config/mongo.js
@@ -1,3 +1,5 @@
 module.exports = {
-    dbName: 'lanflix'
+    dbName: 'lanflix',
+    host: 'localhost',
+    port: 27017
 }

--- a/back-end/services/mongo.service.js
+++ b/back-end/services/mongo.service.js
@@ -1,7 +1,7 @@
 var mongoose = require('mongoose');
 mongoose.Promise = global.Promise;
 var mongoConfig = require('../config/mongo');
-var dbURI = `mongodb://localhost/${mongoConfig.dbName}`;
+var dbURI = `mongodb://${mongoConfig.host}:${mongoConfig.port}/${mongoConfig.dbName}`;
 
 var MongoService = {
     init: init

--- a/docs/MONGODB.md
+++ b/docs/MONGODB.md
@@ -1,1 +1,7 @@
 # MongoDB & MongooseJS
+
+## MongoDB Configuration
+
+All MongoDB configuration can be found in `back-end/service/config/mongo.js`. Currently
+the configuration file only supports a single node Mongo instance without credentials. The
+default configuration assumes a MongoDB node accessible at `localhost:27017`.


### PR DESCRIPTION
This isn't tied to a particular issue but I was going to check out some of your Hacktoberfest issues and noticed that the hostname and port for Mongo are hard-coded. I updated the configuration file to support a different host/port in case someone is running mongo in a VM or docker-machine (or anywhere else other than localhost).