### PR TITLE
proposed file scanner

### DIFF
--- a/back-end/package.json
+++ b/back-end/package.json
@@ -11,7 +11,8 @@
   "license": "MIT",
   "dependencies": {
     "express": "^4.16.2",
-    "mongoose": "^4.12.2"
+    "mongoose": "^4.12.2",
+    "readdir-enhanced": "^2.0.0"
   },
   "devDependencies": {
     "reload": "^2.2.2"

--- a/back-end/services/fileScanner.service.js
+++ b/back-end/services/fileScanner.service.js
@@ -1,0 +1,78 @@
+var fs = require('fs');
+var path = require('path');
+
+var getFilePaths = function (folderPath, extensions) {
+    const extensionFilter = file => {
+        const ext = path.extname(file).replace('.', '')
+        return extensions.includes(ext);
+    }
+    const readFolder = folderPath => {
+        return new Promise((resolve, reject) => {
+            fs.readdir(folderPath, (err, list) => {
+                if (err) reject(err);
+                resolve(
+                    Promise.all(
+                        list.map(file => readFile(path.resolve(folderPath, file)))
+                    )
+                );
+            })
+        }).then(finalList => {
+            return finalList.reduce((list, item) => {
+                if(!item) return list;
+    
+                if(Array.isArray(item)) {
+                    list.push(...item);
+                } else {
+                    list.push(item);
+                }
+                return list;
+            }, [])
+        })
+    }
+    
+    const readFile = filePath => {
+        return new Promise((resolve, reject) => {
+            isFile(filePath).then(flag => {
+                if(flag) {
+                    if(extensionFilter(filePath)) {
+                        resolve(filePath);
+                    } else {
+                        resolve()
+                    }
+                } else {
+                    resolve(readFolder(filePath));
+                }
+            })
+        });
+    }
+    
+    const isFile = filePath => {
+        return new Promise((resolve, reject) => {
+            fs.lstat(filePath, (err, stats) => {
+                if(err) reject(err);
+                resolve(!stats.isDirectory())
+            })
+        });
+    }
+
+    return readFolder(folderPath);
+}
+
+const mapToEpisodes = episodePaths => (
+    episodePaths.map(episodePath => {
+        // TODO: matching pattern 
+        // var matchRegex = ''
+        return episodePath; 
+    })
+)
+
+const findVideoFiles = (folderPath, extensions) => {
+    return getFilePaths(folderPath, extensions)
+        .then(mapToEpisodes);
+}
+
+var fileScannerService = {
+    findVideoFiles : findVideoFiles
+}
+
+module.exports = fileScannerService;

--- a/back-end/services/fs.service.module.js
+++ b/back-end/services/fs.service.module.js
@@ -1,0 +1,53 @@
+var fs = require('fs');
+var path = require('path');
+var readdir = require('readdir-enhanced');
+
+/**
+ * Returns true when filePath includes any of extensions
+ * @param {String} filePath
+ * @param {String[]} extensions
+ * @return {Boolean}
+ */
+function extensionFilter(filePath, extensions) {
+    var ext = path.extname(filePath).replace('.', '')
+    return extensions.includes(ext);
+}
+
+/**
+ * Gets file paths for given extensions
+ * @param {String} folderPath 
+ * @param {String[]} extensions
+ * @returns Promise of string array
+ */
+function getFilePaths(folderPath, extensions) {
+    return readdir(folderPath, { deep: true })
+        .then(function (list) {
+            return list.filter(function (filePath) {
+                return extensionFilter(path.resolve(folderPath, filePath), extensions);
+            });
+        });
+}
+
+/**
+ * Parse the filePath and generate episode object
+ * @param {String} filePath
+ * @return {Object} 
+ */
+function mapFilePathToEpisode (filePath) {
+    // TODO: matching pattern 
+    // var matchRegex = ''
+    return filePath; 
+}
+
+function findVideoFiles(folderPath, extensions) {
+    return getFilePaths(folderPath, extensions)
+        .then(function(list) {
+            return list.map(mapFilePathToEpisode);
+        })
+}
+
+var fileScannerService = {
+    findVideoFiles : findVideoFiles
+}
+
+module.exports = fileScannerService;


### PR DESCRIPTION
Implementation trial for #19 

I committed two approaches:
- One with using `readdir-enhanced` npm module 
- Other is implemented with native promises and node.js `fs` module

generating episode objects from filePath can be in an another issue

My opinion: using npm module is more clean and readable approach. I would pick that :D